### PR TITLE
Eigene YOrm-Model-Class verwenden können 

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -7,6 +7,7 @@ use product;
 use product_category;
 use product_variant;
 
+if(1 !== \rex_config::get('product', 'use_own_model')) {
 rex_yform_manager_dataset::setModelClass(
     'rex_product',
     product::class
@@ -20,6 +21,7 @@ rex_yform_manager_dataset::setModelClass(
     'rex_product_variant',
     product_variant::class
 );
+}
 
 \rex_extension::register('YFORM_DATA_LIST', static function ($ep) {
 

--- a/package.yml
+++ b/package.yml
@@ -45,3 +45,4 @@ page:
 
 default_config:
     'default_thumbnail': "product_fallback_image.png"
+    'use_own_model': 0

--- a/pages/settings.php
+++ b/pages/settings.php
@@ -11,6 +11,13 @@ $field->setPreview(1);
 $field->setTypes('jpg,gif,png');
 $field->setLabel('Vorschau-Bild');
 
+/* Select-Auswahl, ob eigene Model Class verwendet werden soll */
+$field = $form->addSelectField('use_own_model');
+$field->setLabel('Eigene Model-Klasse verwenden?');
+$select = $field->getSelect();
+$select->addOption('Ja', 1);
+$select->addOption('Nein', 0);
+
 $fragment = new rex_fragment();
 $fragment->setVar('class', 'edit', false);
 $fragment->setVar('title', $addon->i18n('product_settings'), false);


### PR DESCRIPTION
Mit dieser Einstellung kann der Abschnitt in der `boot.php` deaktiviert werden, um eigene projektspezifische Klassen und Methoden definieren zu können.

```
rex_yform_manager_dataset::setModelClass(
    'rex_product',
    product::class
);
rex_yform_manager_dataset::setModelClass(
    'rex_product_category',
    product_category::class
);

rex_yform_manager_dataset::setModelClass(
    'rex_product_variant',
    product_variant::class
);
```